### PR TITLE
Add support for customer provided Encryption keys

### DIFF
--- a/azblob/customer_provided_encryption_keys.go
+++ b/azblob/customer_provided_encryption_keys.go
@@ -34,8 +34,8 @@ type blobEncryptionHeaders struct {
 }
 
 // newBlobEncryptionHeader creates a new blobEncryptionHeaders. A nil key is
-// is a valid input and indicates that this type of encryption won't be used.
-// A non-nil key must have length 32.
+// a valid input and indicates that this type of encryption won't be used. A
+// non-nil key must have length 32.
 func newBlobEncryptionHeader(key []byte) (*blobEncryptionHeaders, error) {
 	if key == nil {
 		return nil, nil

--- a/azblob/customer_provided_encryption_keys.go
+++ b/azblob/customer_provided_encryption_keys.go
@@ -1,0 +1,69 @@
+package azblob
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/rubrikinc/azure-pipeline-go/pipeline"
+)
+
+const (
+	encryptionAlgorithm = "AES256"
+)
+
+// CustomerEncryptionKey is AES265 encryption key for azure customer provided
+// encryption key feature. If it is nil, it means that customer encryption keys
+// will not be used.
+type CustomerEncryptionKey []byte
+
+// InvalidAES256KeyLength is returned when the provided key has an invalid
+// length.
+type InvalidAES256KeyLength error
+
+func newInvalidAES256KeyLength(length int) InvalidAES256KeyLength {
+	return fmt.Errorf("Invalid key length, must be 32 bytes: %d", length)
+}
+
+// blobEncryptionHeaders includes the http headers needed for using Customer
+// provided encryption.
+type blobEncryptionHeaders struct {
+	key     string
+	keySha2 string
+}
+
+// newBlobEncryptionHeader creates a new blobEncryptionHeaders. A nil key is
+// is a valid input and indicates that this type of encryption won't be used.
+// A non-nil key must have length 32.
+func newBlobEncryptionHeader(key []byte) (*blobEncryptionHeaders, error) {
+	if key == nil {
+		return nil, nil
+	}
+	// sha2 requires 32 bytes encryption key.
+	if len(key) != 32 {
+		return nil, newInvalidAES256KeyLength(len(key))
+	}
+	eKey := make([]byte, base64.StdEncoding.EncodedLen(len(key)))
+	base64.StdEncoding.Encode(eKey, key)
+	sKeyHash := sha256.Sum256(key)
+	sKey := make([]byte, base64.StdEncoding.EncodedLen(len(sKeyHash)))
+	base64.StdEncoding.Encode(sKey, sKeyHash[:])
+	return &blobEncryptionHeaders{
+		key:     string(eKey),
+		keySha2: string(sKey),
+	}, nil
+}
+
+// setEncryptionHeaders augments a http request with the encryption headers, if
+// necessary.
+func setEncryptionHeaders(
+	req pipeline.Request,
+	enc *blobEncryptionHeaders,
+) pipeline.Request {
+	if enc != nil {
+		req.Header.Set("x-ms-encryption-key", enc.key)
+		req.Header.Set("x-ms-encryption-key-sha256", enc.keySha2)
+		req.Header.Set("x-ms-encryption-algorithm", encryptionAlgorithm)
+	}
+	return req
+}

--- a/azblob/customer_provided_encryption_keys.go
+++ b/azblob/customer_provided_encryption_keys.go
@@ -12,7 +12,7 @@ const (
 	encryptionAlgorithm = "AES256"
 )
 
-// CustomerEncryptionKey is AES265 encryption key for azure customer provided
+// CustomerEncryptionKey is AES256 encryption key for azure customer provided
 // encryption key feature. If it is nil, it means that customer encryption keys
 // will not be used.
 type CustomerEncryptionKey []byte
@@ -26,7 +26,8 @@ func newInvalidAES256KeyLength(length int) InvalidAES256KeyLength {
 }
 
 // blobEncryptionHeaders includes the http headers needed for using Customer
-// provided encryption.
+// provided encryption. These are base64 encoded as specified here
+// https://azure.microsoft.com/en-us/blog/customer-provided-keys-with-azure-storage-service-encryption/
 type blobEncryptionHeaders struct {
 	key     string
 	keySha2 string

--- a/azblob/zz_generated_blob.go
+++ b/azblob/zz_generated_blob.go
@@ -625,14 +625,14 @@ func (client blobClient) deleteResponder(resp pipeline.Response) (pipeline.Respo
 // an ETag value to operate only on blobs with a matching value. ifNoneMatch is specify an ETag value to operate only
 // on blobs without a matching value. requestID is provides a client-generated, opaque value with a 1 KB character
 // limit that is recorded in the analytics logs when storage analytics logging is enabled.
-func (client blobClient) Download(ctx context.Context, snapshot *string, timeout *int32, rangeParameter *string, leaseID *string, rangeGetContentMD5 *bool, ifModifiedSince *time.Time, ifUnmodifiedSince *time.Time, ifMatch *ETag, ifNoneMatch *ETag, requestID *string) (*downloadResponse, error) {
+func (client blobClient) Download(ctx context.Context, snapshot *string, timeout *int32, rangeParameter *string, leaseID *string, rangeGetContentMD5 *bool, ifModifiedSince *time.Time, ifUnmodifiedSince *time.Time, ifMatch *ETag, ifNoneMatch *ETag, requestID *string, encHeaders *blobEncryptionHeaders) (*downloadResponse, error) {
 	if err := validate([]validation{
 		{targetValue: timeout,
 			constraints: []constraint{{target: "timeout", name: null, rule: false,
 				chain: []constraint{{target: "timeout", name: inclusiveMinimum, rule: 0, chain: nil}}}}}}); err != nil {
 		return nil, err
 	}
-	req, err := client.downloadPreparer(snapshot, timeout, rangeParameter, leaseID, rangeGetContentMD5, ifModifiedSince, ifUnmodifiedSince, ifMatch, ifNoneMatch, requestID)
+	req, err := client.downloadPreparer(snapshot, timeout, rangeParameter, leaseID, rangeGetContentMD5, ifModifiedSince, ifUnmodifiedSince, ifMatch, ifNoneMatch, requestID, encHeaders)
 	if err != nil {
 		return nil, err
 	}
@@ -644,7 +644,7 @@ func (client blobClient) Download(ctx context.Context, snapshot *string, timeout
 }
 
 // downloadPreparer prepares the Download request.
-func (client blobClient) downloadPreparer(snapshot *string, timeout *int32, rangeParameter *string, leaseID *string, rangeGetContentMD5 *bool, ifModifiedSince *time.Time, ifUnmodifiedSince *time.Time, ifMatch *ETag, ifNoneMatch *ETag, requestID *string) (pipeline.Request, error) {
+func (client blobClient) downloadPreparer(snapshot *string, timeout *int32, rangeParameter *string, leaseID *string, rangeGetContentMD5 *bool, ifModifiedSince *time.Time, ifUnmodifiedSince *time.Time, ifMatch *ETag, ifNoneMatch *ETag, requestID *string, encHeaders *blobEncryptionHeaders) (pipeline.Request, error) {
 	req, err := pipeline.NewRequest("GET", client.url, nil)
 	if err != nil {
 		return req, pipeline.NewError(err, "failed to create request")
@@ -682,6 +682,7 @@ func (client blobClient) downloadPreparer(snapshot *string, timeout *int32, rang
 	if requestID != nil {
 		req.Header.Set("x-ms-client-request-id", *requestID)
 	}
+	setEncryptionHeaders(req, encHeaders)
 	return req, nil
 }
 
@@ -747,14 +748,14 @@ func (client blobClient) getAccountInfoResponder(resp pipeline.Response) (pipeli
 // blobs with a matching value. ifNoneMatch is specify an ETag value to operate only on blobs without a matching value.
 // requestID is provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics
 // logs when storage analytics logging is enabled.
-func (client blobClient) GetProperties(ctx context.Context, snapshot *string, timeout *int32, leaseID *string, ifModifiedSince *time.Time, ifUnmodifiedSince *time.Time, ifMatch *ETag, ifNoneMatch *ETag, requestID *string) (*BlobGetPropertiesResponse, error) {
+func (client blobClient) GetProperties(ctx context.Context, snapshot *string, timeout *int32, leaseID *string, ifModifiedSince *time.Time, ifUnmodifiedSince *time.Time, ifMatch *ETag, ifNoneMatch *ETag, requestID *string, encHeaders *blobEncryptionHeaders) (*BlobGetPropertiesResponse, error) {
 	if err := validate([]validation{
 		{targetValue: timeout,
 			constraints: []constraint{{target: "timeout", name: null, rule: false,
 				chain: []constraint{{target: "timeout", name: inclusiveMinimum, rule: 0, chain: nil}}}}}}); err != nil {
 		return nil, err
 	}
-	req, err := client.getPropertiesPreparer(snapshot, timeout, leaseID, ifModifiedSince, ifUnmodifiedSince, ifMatch, ifNoneMatch, requestID)
+	req, err := client.getPropertiesPreparer(snapshot, timeout, leaseID, ifModifiedSince, ifUnmodifiedSince, ifMatch, ifNoneMatch, requestID, encHeaders)
 	if err != nil {
 		return nil, err
 	}
@@ -766,7 +767,7 @@ func (client blobClient) GetProperties(ctx context.Context, snapshot *string, ti
 }
 
 // getPropertiesPreparer prepares the GetProperties request.
-func (client blobClient) getPropertiesPreparer(snapshot *string, timeout *int32, leaseID *string, ifModifiedSince *time.Time, ifUnmodifiedSince *time.Time, ifMatch *ETag, ifNoneMatch *ETag, requestID *string) (pipeline.Request, error) {
+func (client blobClient) getPropertiesPreparer(snapshot *string, timeout *int32, leaseID *string, ifModifiedSince *time.Time, ifUnmodifiedSince *time.Time, ifMatch *ETag, ifNoneMatch *ETag, requestID *string, encHeaders *blobEncryptionHeaders) (pipeline.Request, error) {
 	req, err := pipeline.NewRequest("HEAD", client.url, nil)
 	if err != nil {
 		return req, pipeline.NewError(err, "failed to create request")
@@ -798,6 +799,7 @@ func (client blobClient) getPropertiesPreparer(snapshot *string, timeout *int32,
 	if requestID != nil {
 		req.Header.Set("x-ms-client-request-id", *requestID)
 	}
+	setEncryptionHeaders(req, encHeaders)
 	return req, nil
 }
 
@@ -1076,14 +1078,14 @@ func (client blobClient) setHTTPHeadersResponder(resp pipeline.Response) (pipeli
 // to operate only on blobs with a matching value. ifNoneMatch is specify an ETag value to operate only on blobs
 // without a matching value. requestID is provides a client-generated, opaque value with a 1 KB character limit that is
 // recorded in the analytics logs when storage analytics logging is enabled.
-func (client blobClient) SetMetadata(ctx context.Context, timeout *int32, metadata map[string]string, leaseID *string, ifModifiedSince *time.Time, ifUnmodifiedSince *time.Time, ifMatch *ETag, ifNoneMatch *ETag, requestID *string) (*BlobSetMetadataResponse, error) {
+func (client blobClient) SetMetadata(ctx context.Context, timeout *int32, metadata map[string]string, leaseID *string, ifModifiedSince *time.Time, ifUnmodifiedSince *time.Time, ifMatch *ETag, ifNoneMatch *ETag, requestID *string, encHeaders *blobEncryptionHeaders) (*BlobSetMetadataResponse, error) {
 	if err := validate([]validation{
 		{targetValue: timeout,
 			constraints: []constraint{{target: "timeout", name: null, rule: false,
 				chain: []constraint{{target: "timeout", name: inclusiveMinimum, rule: 0, chain: nil}}}}}}); err != nil {
 		return nil, err
 	}
-	req, err := client.setMetadataPreparer(timeout, metadata, leaseID, ifModifiedSince, ifUnmodifiedSince, ifMatch, ifNoneMatch, requestID)
+	req, err := client.setMetadataPreparer(timeout, metadata, leaseID, ifModifiedSince, ifUnmodifiedSince, ifMatch, ifNoneMatch, requestID, encHeaders)
 	if err != nil {
 		return nil, err
 	}
@@ -1095,7 +1097,7 @@ func (client blobClient) SetMetadata(ctx context.Context, timeout *int32, metada
 }
 
 // setMetadataPreparer prepares the SetMetadata request.
-func (client blobClient) setMetadataPreparer(timeout *int32, metadata map[string]string, leaseID *string, ifModifiedSince *time.Time, ifUnmodifiedSince *time.Time, ifMatch *ETag, ifNoneMatch *ETag, requestID *string) (pipeline.Request, error) {
+func (client blobClient) setMetadataPreparer(timeout *int32, metadata map[string]string, leaseID *string, ifModifiedSince *time.Time, ifUnmodifiedSince *time.Time, ifMatch *ETag, ifNoneMatch *ETag, requestID *string, encHeaders *blobEncryptionHeaders) (pipeline.Request, error) {
 	req, err := pipeline.NewRequest("PUT", client.url, nil)
 	if err != nil {
 		return req, pipeline.NewError(err, "failed to create request")
@@ -1130,6 +1132,7 @@ func (client blobClient) setMetadataPreparer(timeout *int32, metadata map[string
 	if requestID != nil {
 		req.Header.Set("x-ms-client-request-id", *requestID)
 	}
+	setEncryptionHeaders(req, encHeaders)
 	return req, nil
 }
 


### PR DESCRIPTION
We create support for encryption headers. The main endpoint will just have a new `encKey CustomerEncryptionKey` parameter. The library computes the base64 and Sha2 base64 encoding and attach them as the appropriate header to the http request for azure. 

We also support ordinary (not using customer encryption keys) usage of library by using a nil key.