### PR TITLE
Fix a bug in zz_response_helpers

### DIFF
--- a/azblob/highlevel.go
+++ b/azblob/highlevel.go
@@ -208,7 +208,7 @@ func downloadBlobToBuffer(ctx context.Context, blobURL BlobURL, offset int64, co
 			if err != nil {
 				return err
 			}
-			body := dr.Body(o.RetryReaderOptionsPerBlock)
+			body := dr.Body(o.RetryReaderOptionsPerBlock, nil)
 			if o.Progress != nil {
 				rangeProgress := int64(0)
 				body = pipeline.NewResponseBodyProgress(

--- a/azblob/zz_response_helpers.go
+++ b/azblob/zz_response_helpers.go
@@ -57,7 +57,7 @@ type DownloadResponse struct {
 // while reading, it will make additional requests to reestablish a connection and
 // continue reading. Specifying a RetryReaderOption's with MaxRetryRequests set to 0
 // (the default), returns the original response body and no retries will be performed.
-func (r *DownloadResponse) Body(o RetryReaderOptions) io.ReadCloser {
+func (r *DownloadResponse) Body(o RetryReaderOptions, encKey CustomerEncryptionKey) io.ReadCloser {
 	if o.MaxRetryRequests == 0 { // No additional retries
 		return r.Response().Body
 	}
@@ -67,7 +67,7 @@ func (r *DownloadResponse) Body(o RetryReaderOptions) io.ReadCloser {
 				BlobAccessConditions{
 					ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: getInfo.ETag},
 				},
-				false)
+				false, encKey)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
We missed the need to have encryption key in the DownloadBody retry part in the previous diff. This fixes the issue. 