### PR TITLE
Customer encryption key 070

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -110,12 +110,12 @@
   revision = "91bb50d981495aef1c208d31be3d77d904384f20"
 
 [[projects]]
-  digest = "1:602649ff074ccee9273e1d3b25c4069f13a70fa0c232957c7d68a6f02fb7a9ea"
+  branch = "rubrik_branch_encryption"
+  digest = "1:af243c71f6c15ff22f3fede66824a94c227b9d174def26b32700cd00c1d6daa7"
   name = "github.com/rubrikinc/azure-pipeline-go"
   packages = ["pipeline"]
   pruneopts = "UT"
-  revision = "232aee85e8e3a6223a11c0943f7df2ae0fac00e4"
-  version = "v0.2.2"
+  revision = "060c7bca37f73a864d4669d7cf8d233d36d00d85"
 
 [[projects]]
   digest = "1:4c93890bbbb5016505e856cb06b5c5a2ff5b7217584d33f2a9071ebef4b5d473"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/rubrikinc/azure-pipeline-go"
-  version = "0.2.1"
+  branch = "rubrik_branch_encryption"
 
 [[constraint]]
   branch = "v1"

--- a/azblob/zc_storage_error.go
+++ b/azblob/zc_storage_error.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"github.com/rubrikinc/azure-pipeline-go/pipeline"
 	"net/http"
+
+	"github.com/rubrikinc/azure-pipeline-go/pipeline"
 )
 
 func init() {
@@ -57,7 +58,7 @@ func (e *storageError) Error() string {
 	fmt.Fprintf(b, "Description=%s, Details: ", e.description)
 	// Note: The following prints out all the headers of the request that
 	// had errored out. This is usually unnecessary and had previously caused
-	// overload for the logging infrastructure. 
+	// overload for the logging infrastructure.
 
 	//if len(e.details) == 0 {
 	//	b.WriteString("(none)\n")

--- a/azblob/zc_storage_error.go
+++ b/azblob/zc_storage_error.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"net/http"
-	"sort"
-
 	"github.com/rubrikinc/azure-pipeline-go/pipeline"
+	"net/http"
 )
 
 func init() {
@@ -57,22 +55,26 @@ func (e *storageError) Error() string {
 	b := &bytes.Buffer{}
 	fmt.Fprintf(b, "===== RESPONSE ERROR (ServiceCode=%s) =====\n", e.serviceCode)
 	fmt.Fprintf(b, "Description=%s, Details: ", e.description)
-	if len(e.details) == 0 {
-		b.WriteString("(none)\n")
-	} else {
-		b.WriteRune('\n')
-		keys := make([]string, 0, len(e.details))
-		// Alphabetize the details
-		for k := range e.details {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, k := range keys {
-			fmt.Fprintf(b, "   %s: %+v\n", k, e.details[k])
-		}
-	}
-	req := pipeline.Request{Request: e.response.Request}.Copy() // Make a copy of the response's request
-	pipeline.WriteRequestWithResponse(b, prepareRequestForLogging(req), e.response, nil)
+	// Note: The following prints out all the headers of the request that
+	// had errored out. This is usually unnecessary and had previously caused
+	// overload for the logging infrastructure. 
+
+	//if len(e.details) == 0 {
+	//	b.WriteString("(none)\n")
+	//} else {
+	//	b.WriteRune('\n')
+	//	keys := make([]string, 0, len(e.details))
+	//	// Alphabetize the details
+	//	for k := range e.details {
+	//		keys = append(keys, k)
+	//	}
+	//	sort.Strings(keys)
+	//	for _, k := range keys {
+	//		fmt.Fprintf(b, "   %s: %+v\n", k, e.details[k])
+	//	}
+	//}
+	//req := pipeline.Request{Request: e.response.Request}.Copy() // Make a copy of the response's request
+	//pipeline.WriteRequestWithResponse(b, prepareRequestForLogging(req), e.response, nil)
 	return e.ErrorNode.Error(b.String())
 }
 


### PR DESCRIPTION
We trim the logs from some extra unnecessary headers and also include a change in azure-pipeline-go, which redacts the encryption keys in all situations. 

This makes sure we won't be leaking the encryption key and sha2 hashe accidentally in upstream applications. 